### PR TITLE
optimizing queries

### DIFF
--- a/src/services/__tests__/schedule.service.test.ts
+++ b/src/services/__tests__/schedule.service.test.ts
@@ -1190,7 +1190,7 @@ describe('ScheduleService - Waitlist and Booking Limits logic', () => {
 describe('ScheduleService - getSchedulesResumeRange', () => {
   let scheduleService: ScheduleService;
   let mockEntityManager: any;
-  let executeMock: jest.Mock;
+  let qb: any;
 
   const currentUser = {
     id: 'u1',
@@ -1198,36 +1198,56 @@ describe('ScheduleService - getSchedulesResumeRange', () => {
     contextRole: UserRoleEnum.STANDARD,
   } as any;
 
+  // Chainable QueryBuilder mock: every builder method returns `qb`, and the two
+  // terminal calls (applyFilters / execute) are async.
+  const makeQb = () => {
+    const builder: any = {};
+    for (const m of [
+      'select',
+      'addSelect',
+      'leftJoin',
+      'where',
+      'groupBy',
+      'orderBy',
+    ]) {
+      builder[m] = jest.fn(() => builder);
+    }
+    builder.applyFilters = jest.fn(async () => {});
+    builder.execute = jest.fn(async () => []);
+    return builder;
+  };
+
   beforeEach(() => {
-    executeMock = jest.fn();
+    qb = makeQb();
     mockEntityManager = {
       findOne: jest.fn(),
-      getConnection: jest.fn(() => ({ execute: executeMock })),
-      getRepository: jest.fn(),
+      createQueryBuilder: jest.fn(() => qb),
     };
     scheduleService = new ScheduleService(mockEntityManager as any);
   });
 
-  it('maps raw rows to the resume shape and returns scheduleOptions', async () => {
+  it('maps QueryBuilder rows to the resume shape and returns scheduleOptions', async () => {
     const start = moment('2026-01-01').toDate();
     const end = moment('2026-01-14').toDate();
     mockEntityManager.findOne.mockResolvedValue({
       scheduleOptions: { id: 'opt-1', maxActiveReservations: 2 },
     });
-    executeMock.mockResolvedValue([
+    // execute() maps columns to entity property names; COUNT comes back as a
+    // bigint string from node-postgres.
+    qb.execute.mockResolvedValue([
       {
         id: 's1',
-        start_date: start,
-        max_users: 10,
+        startDate: start,
+        maxUsers: 10,
         state: ScheduleState.AVAILABLE,
-        ocupancy: 3,
+        ocupancy: '3',
       },
       {
         id: 's2',
-        start_date: end,
-        max_users: 5,
+        startDate: end,
+        maxUsers: 5,
         state: ScheduleState.CANCELLED,
-        ocupancy: 0,
+        ocupancy: '0',
       },
     ]);
 
@@ -1244,7 +1264,7 @@ describe('ScheduleService - getSchedulesResumeRange', () => {
         startDate: start,
         maxUsers: 10,
         state: ScheduleState.AVAILABLE,
-        ocupancy: 3,
+        ocupancy: 3, // normalised to a number
       },
       {
         id: 's2',
@@ -1257,9 +1277,8 @@ describe('ScheduleService - getSchedulesResumeRange', () => {
     expect(res.scheduleOptions).toEqual({ id: 'opt-1', maxActiveReservations: 2 });
   });
 
-  it('resolves schedules + ocupancy in a single DB round-trip (correlated count)', async () => {
+  it('resolves schedules + ocupancy in a single query (one execute)', async () => {
     mockEntityManager.findOne.mockResolvedValue(null);
-    executeMock.mockResolvedValue([]);
 
     await scheduleService.getSchedulesResumeRange(
       currentUser,
@@ -1267,16 +1286,12 @@ describe('ScheduleService - getSchedulesResumeRange', () => {
       new Date()
     );
 
-    // Exactly one raw statement for the schedules + their occupancy.
-    expect(executeMock).toHaveBeenCalledTimes(1);
-    const sql = String(executeMock.mock.calls[0][0]).toLowerCase();
-    expect(sql).toContain('user_schedules');
-    expect(sql).toContain('count(');
+    expect(qb.execute).toHaveBeenCalledTimes(1);
+    expect(qb.leftJoin).toHaveBeenCalledWith('s.users', 'u');
   });
 
-  it('scopes the raw query to the active company (raw SQL bypasses the companyContext filter)', async () => {
+  it('applies entity filters so the query stays company-scoped (v6 QB does not auto-apply)', async () => {
     mockEntityManager.findOne.mockResolvedValue(null);
-    executeMock.mockResolvedValue([]);
 
     await scheduleService.getSchedulesResumeRange(
       currentUser,
@@ -1284,15 +1299,15 @@ describe('ScheduleService - getSchedulesResumeRange', () => {
       new Date()
     );
 
-    const [sql, params] = executeMock.mock.calls[0];
-    expect(String(sql).toLowerCase()).toContain('company_id');
-    // activeCompanyId must be bound as a parameter, not interpolated.
-    expect(params).toContain(currentUser.activeCompanyId);
+    // Regression guard: dropping applyFilters() would leak schedules across tenants.
+    expect(qb.applyFilters).toHaveBeenCalledTimes(1);
+    expect(qb.applyFilters.mock.invocationCallOrder[0]).toBeLessThan(
+      qb.execute.mock.invocationCallOrder[0]
+    );
   });
 
   it('returns null scheduleOptions when no company is found', async () => {
     mockEntityManager.findOne.mockResolvedValue(null);
-    executeMock.mockResolvedValue([]);
 
     const res: any = await scheduleService.getSchedulesResumeRange(
       currentUser,

--- a/src/services/__tests__/schedule.service.test.ts
+++ b/src/services/__tests__/schedule.service.test.ts
@@ -1,3 +1,4 @@
+import { LoadStrategy } from '@mikro-orm/core';
 import moment from 'moment';
 
 import { Company } from '../../entities/Company';
@@ -1327,6 +1328,90 @@ describe('ScheduleService - getSchedulesResumeRange', () => {
         new Date(),
         new Date()
       )
+    ).rejects.toThrow();
+  });
+});
+
+describe('ScheduleService - getSchedulesRange', () => {
+  let scheduleService: ScheduleService;
+  let mockEntityManager: any;
+  let scheduleRepo: any;
+
+  const currentUser = {
+    id: 'u1',
+    activeCompanyId: 'c1',
+    contextRole: UserRoleEnum.STANDARD,
+  } as any;
+
+  beforeEach(() => {
+    scheduleRepo = { find: jest.fn(async () => []) };
+    mockEntityManager = {
+      getRepository: jest.fn(() => scheduleRepo),
+      populate: jest.fn(async () => {}),
+      getReference: jest.fn((_entity: any, id: string) => ({ id })),
+    };
+    scheduleService = new ScheduleService(mockEntityManager as any);
+  });
+
+  it('loads users + admin JOINED in one query and waitListUsers via select-in (2 round-trips, no cartesian)', async () => {
+    await scheduleService.getSchedulesRange(
+      currentUser,
+      new Date(),
+      new Date()
+    );
+
+    // Round-trip 1: a single find joining the to-one (admin) and ONE to-many
+    // (users). waitListUsers is deliberately NOT joined here — joining two
+    // to-many collections together would explode into a cartesian product.
+    expect(scheduleRepo.find).toHaveBeenCalledTimes(1);
+    const [, options] = scheduleRepo.find.mock.calls[0];
+    expect(options.populate).toEqual(
+      expect.arrayContaining(['users', 'admin'])
+    );
+    expect(options.populate).not.toContain('waitListUsers');
+    expect(options.strategy).toBe(LoadStrategy.JOINED);
+
+    // Round-trip 2: the second to-many loaded on its own via select-in.
+    expect(mockEntityManager.populate).toHaveBeenCalledTimes(1);
+    const [, populateHint, populateOpts] =
+      mockEntityManager.populate.mock.calls[0];
+    expect(populateHint).toEqual(['waitListUsers']);
+    expect(populateOpts.strategy).toBe(LoadStrategy.SELECT_IN);
+  });
+
+  it('returns the schedules sorted by startDate ascending (contract unchanged)', async () => {
+    const later = { id: 's2', startDate: '2026-01-02 10:00:00', admin: { id: 'a2' } };
+    const earlier = { id: 's1', startDate: '2026-01-01 09:00:00', admin: { id: 'a1' } };
+    scheduleRepo.find.mockResolvedValue([later, earlier]);
+
+    const res: any = await scheduleService.getSchedulesRange(
+      currentUser,
+      new Date(),
+      new Date()
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.schedules.map((s: any) => s.id)).toEqual(['s1', 's2']);
+  });
+
+  it('filters to the current user\'s own schedules when mySchedules is true', async () => {
+    const mine = { id: 's1', startDate: '2026-01-01 09:00:00', admin: { id: 'u1' } };
+    const others = { id: 's2', startDate: '2026-01-02 10:00:00', admin: { id: 'zzz' } };
+    scheduleRepo.find.mockResolvedValue([mine, others]);
+
+    const res: any = await scheduleService.getSchedulesRange(
+      currentUser,
+      new Date(),
+      new Date(),
+      true
+    );
+
+    expect(res.schedules.map((s: any) => s.id)).toEqual(['s1']);
+  });
+
+  it('throws when there is no authenticated user', async () => {
+    await expect(
+      scheduleService.getSchedulesRange(null as any, new Date(), new Date())
     ).rejects.toThrow();
   });
 });

--- a/src/services/__tests__/schedule.service.test.ts
+++ b/src/services/__tests__/schedule.service.test.ts
@@ -1186,3 +1186,132 @@ describe('ScheduleService - Waitlist and Booking Limits logic', () => {
     });
   });
 });
+
+describe('ScheduleService - getSchedulesResumeRange', () => {
+  let scheduleService: ScheduleService;
+  let mockEntityManager: any;
+  let executeMock: jest.Mock;
+
+  const currentUser = {
+    id: 'u1',
+    activeCompanyId: 'c1',
+    contextRole: UserRoleEnum.STANDARD,
+  } as any;
+
+  beforeEach(() => {
+    executeMock = jest.fn();
+    mockEntityManager = {
+      findOne: jest.fn(),
+      getConnection: jest.fn(() => ({ execute: executeMock })),
+      getRepository: jest.fn(),
+    };
+    scheduleService = new ScheduleService(mockEntityManager as any);
+  });
+
+  it('maps raw rows to the resume shape and returns scheduleOptions', async () => {
+    const start = moment('2026-01-01').toDate();
+    const end = moment('2026-01-14').toDate();
+    mockEntityManager.findOne.mockResolvedValue({
+      scheduleOptions: { id: 'opt-1', maxActiveReservations: 2 },
+    });
+    executeMock.mockResolvedValue([
+      {
+        id: 's1',
+        start_date: start,
+        max_users: 10,
+        state: ScheduleState.AVAILABLE,
+        ocupancy: 3,
+      },
+      {
+        id: 's2',
+        start_date: end,
+        max_users: 5,
+        state: ScheduleState.CANCELLED,
+        ocupancy: 0,
+      },
+    ]);
+
+    const res: any = await scheduleService.getSchedulesResumeRange(
+      currentUser,
+      start,
+      end
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.schedulesResume).toEqual([
+      {
+        id: 's1',
+        startDate: start,
+        maxUsers: 10,
+        state: ScheduleState.AVAILABLE,
+        ocupancy: 3,
+      },
+      {
+        id: 's2',
+        startDate: end,
+        maxUsers: 5,
+        state: ScheduleState.CANCELLED,
+        ocupancy: 0,
+      },
+    ]);
+    expect(res.scheduleOptions).toEqual({ id: 'opt-1', maxActiveReservations: 2 });
+  });
+
+  it('resolves schedules + ocupancy in a single DB round-trip (correlated count)', async () => {
+    mockEntityManager.findOne.mockResolvedValue(null);
+    executeMock.mockResolvedValue([]);
+
+    await scheduleService.getSchedulesResumeRange(
+      currentUser,
+      new Date(),
+      new Date()
+    );
+
+    // Exactly one raw statement for the schedules + their occupancy.
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    const sql = String(executeMock.mock.calls[0][0]).toLowerCase();
+    expect(sql).toContain('user_schedules');
+    expect(sql).toContain('count(');
+  });
+
+  it('scopes the raw query to the active company (raw SQL bypasses the companyContext filter)', async () => {
+    mockEntityManager.findOne.mockResolvedValue(null);
+    executeMock.mockResolvedValue([]);
+
+    await scheduleService.getSchedulesResumeRange(
+      currentUser,
+      new Date(),
+      new Date()
+    );
+
+    const [sql, params] = executeMock.mock.calls[0];
+    expect(String(sql).toLowerCase()).toContain('company_id');
+    // activeCompanyId must be bound as a parameter, not interpolated.
+    expect(params).toContain(currentUser.activeCompanyId);
+  });
+
+  it('returns null scheduleOptions when no company is found', async () => {
+    mockEntityManager.findOne.mockResolvedValue(null);
+    executeMock.mockResolvedValue([]);
+
+    const res: any = await scheduleService.getSchedulesResumeRange(
+      currentUser,
+      new Date(),
+      new Date()
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.schedulesResume).toEqual([]);
+    expect(res.scheduleOptions).toBeNull();
+  });
+
+  it('throws when there is no authenticated user', async () => {
+    await expect(
+      scheduleService.getSchedulesResumeRange(
+        null as any,
+        new Date(),
+        new Date()
+      )
+    ).rejects.toThrow();
+  });
+});

--- a/src/services/schedule.service.ts
+++ b/src/services/schedule.service.ts
@@ -362,34 +362,58 @@ export class ScheduleService extends BaseService {
     }
 
     try {
-      const scheduleRepo = this.em.getRepository(Schedule);
-      const company = await this.em.findOne(
-        Company,
-        { id: { $ne: null } },
-        { populate: ['scheduleOptions'] }
-      );
-      const scheduleOptions = company?.scheduleOptions || null;
-
       const startOfDay = new Date(startDate);
       const endOfDay = new Date(endDate);
 
-      const schedules = await scheduleRepo.find(
-        {
-          startDate: { $gte: startOfDay, $lte: endOfDay },
-        },
-        { populate: ['users', 'admin'] }
-      );
+      // Resolver limitado por latencia: contra un Postgres remoto (Supabase) el
+      // coste del resolver es (nº de queries × latencia de red), no el volumen de
+      // datos. Por eso resolvemos los schedules y su ocupación en UN solo
+      // round-trip mediante un COUNT correlacionado sobre la tabla pivote, en vez
+      // de hidratar la colección M:N `users` (y `admin`, que aquí no se usa).
+      // Además lo lanzamos en paralelo con las opciones de la compañía.
+      //
+      // OJO: esta query es SQL en crudo, así que NO pasa por el filtro
+      // `companyContext` (@Filter default de la entidad Schedule). El scoping por
+      // compañía hay que aplicarlo a mano con `s.company_id = ?`; si no, se
+      // filtrarían schedules de todas las compañías (fuga entre tenants).
+      type ScheduleResumeRow = {
+        id: string;
+        start_date: Date;
+        max_users: number;
+        state: string;
+        ocupancy: number;
+      };
 
-      const sortSchedules = [...schedules].sort((a, b) => {
-        return moment(a.startDate).unix() - moment(b.startDate).unix();
-      });
+      const [company, rows] = await Promise.all([
+        this.em.findOne(
+          Company,
+          { id: { $ne: null } },
+          { populate: ['scheduleOptions'] }
+        ),
+        this.em.getConnection().execute<ScheduleResumeRow[]>(
+          `SELECT s.id,
+                  s.start_date,
+                  s.max_users,
+                  s.state,
+                  (SELECT COUNT(*)
+                     FROM user_schedules us
+                    WHERE us.schedule_id = s.id)::int AS ocupancy
+             FROM schedule s
+            WHERE s.company_id = ?
+              AND s.start_date BETWEEN ? AND ?
+            ORDER BY s.start_date ASC`,
+          [currentUser.activeCompanyId, startOfDay, endOfDay]
+        ),
+      ]);
 
-      const schedulesResume = sortSchedules.map(schedule => ({
-        id: schedule.id,
-        startDate: schedule.startDate,
-        maxUsers: schedule.maxUsers,
-        state: schedule.state,
-        ocupancy: schedule.users.length,
+      const scheduleOptions = company?.scheduleOptions || null;
+
+      const schedulesResume = rows.map((row: ScheduleResumeRow) => ({
+        id: row.id,
+        startDate: row.start_date,
+        maxUsers: row.max_users,
+        state: row.state as ScheduleState,
+        ocupancy: row.ocupancy,
       }));
 
       return createServiceResponse(200, 'Schedules found', true, {

--- a/src/services/schedule.service.ts
+++ b/src/services/schedule.service.ts
@@ -1,4 +1,5 @@
-import { EntityManager } from '@mikro-orm/core';
+import { EntityManager, raw } from '@mikro-orm/core';
+import { SqlEntityManager } from '@mikro-orm/postgresql';
 import moment from 'moment';
 
 import { Company } from '../entities/Company';
@@ -368,21 +369,35 @@ export class ScheduleService extends BaseService {
       // Resolver limitado por latencia: contra un Postgres remoto (Supabase) el
       // coste del resolver es (nº de queries × latencia de red), no el volumen de
       // datos. Por eso resolvemos los schedules y su ocupación en UN solo
-      // round-trip mediante un COUNT correlacionado sobre la tabla pivote, en vez
-      // de hidratar la colección M:N `users` (y `admin`, que aquí no se usa).
-      // Además lo lanzamos en paralelo con las opciones de la compañía.
+      // round-trip: un LEFT JOIN a la M:N + COUNT agrupado, en vez de hidratar la
+      // colección `users` (y `admin`, que aquí no se usa). Lo lanzamos en paralelo
+      // con las opciones de la compañía.
       //
-      // OJO: esta query es SQL en crudo, así que NO pasa por el filtro
-      // `companyContext` (@Filter default de la entidad Schedule). El scoping por
-      // compañía hay que aplicarlo a mano con `s.company_id = ?`; si no, se
-      // filtrarían schedules de todas las compañías (fuga entre tenants).
+      // Usamos el QueryBuilder de MikroORM (relaciones por nombre: `s.users`) en
+      // vez de SQL en crudo. OJO: en v6 el QueryBuilder NO aplica solo los @Filter
+      // de la entidad; hay que llamar a `applyFilters()` explícitamente. Eso añade
+      // el scoping de `companyContext` reutilizando la definición del filtro (con
+      // el companyId que fija el middleware por request), sin hardcodear company_id.
       type ScheduleResumeRow = {
         id: string;
-        start_date: Date;
-        max_users: number;
+        startDate: Date;
+        maxUsers: number;
         state: string;
-        ocupancy: number;
+        ocupancy: number | string;
       };
+
+      // `createQueryBuilder` sólo existe en el EM de SQL; en runtime el driver es
+      // postgres, así que el cast es seguro (mismo patrón que report.service.ts).
+      const qb = (this.em as SqlEntityManager)
+        .createQueryBuilder(Schedule, 's')
+        .select(['s.id', 's.startDate', 's.maxUsers', 's.state'])
+        .addSelect(raw('count(u.id) as ocupancy'))
+        .leftJoin('s.users', 'u')
+        .where({ startDate: { $gte: startOfDay, $lte: endOfDay } })
+        .groupBy('s.id')
+        .orderBy({ startDate: 'asc' });
+
+      await qb.applyFilters();
 
       const [company, rows] = await Promise.all([
         this.em.findOne(
@@ -390,30 +405,18 @@ export class ScheduleService extends BaseService {
           { id: { $ne: null } },
           { populate: ['scheduleOptions'] }
         ),
-        this.em.getConnection().execute<ScheduleResumeRow[]>(
-          `SELECT s.id,
-                  s.start_date,
-                  s.max_users,
-                  s.state,
-                  (SELECT COUNT(*)
-                     FROM user_schedules us
-                    WHERE us.schedule_id = s.id)::int AS ocupancy
-             FROM schedule s
-            WHERE s.company_id = ?
-              AND s.start_date BETWEEN ? AND ?
-            ORDER BY s.start_date ASC`,
-          [currentUser.activeCompanyId, startOfDay, endOfDay]
-        ),
+        qb.execute<ScheduleResumeRow[]>(),
       ]);
 
       const scheduleOptions = company?.scheduleOptions || null;
 
       const schedulesResume = rows.map((row: ScheduleResumeRow) => ({
         id: row.id,
-        startDate: row.start_date,
-        maxUsers: row.max_users,
+        startDate: row.startDate,
+        maxUsers: row.maxUsers,
         state: row.state as ScheduleState,
-        ocupancy: row.ocupancy,
+        // COUNT vuelve como bigint (string en node-postgres); normalizamos a number.
+        ocupancy: Number(row.ocupancy),
       }));
 
       return createServiceResponse(200, 'Schedules found', true, {

--- a/src/services/schedule.service.ts
+++ b/src/services/schedule.service.ts
@@ -1,4 +1,4 @@
-import { EntityManager, raw } from '@mikro-orm/core';
+import { EntityManager, LoadStrategy, raw } from '@mikro-orm/core';
 import { SqlEntityManager } from '@mikro-orm/postgresql';
 import moment from 'moment';
 
@@ -318,12 +318,27 @@ export class ScheduleService extends BaseService {
       const startOfDay = moment(startDate).format('YYYY/MM/DD HH:mm:ss');
       const endOfDay = moment(endDate).format('YYYY/MM/DD HH:mm:ss');
 
+      // Resolver limitado por latencia (Supabase remoto): el coste es
+      // nº de round-trips × latencia, no el volumen. La estrategia por defecto
+      // (select-in) hace una query por relación → ~4 viajes. Colapsamos a 2 sin
+      // arriesgar un producto cartesiano:
+      //   1) find con JOINED de `admin` (to-one, gratis) + `users` (UNA to-many:
+      //      un solo LEFT JOIN, sin multiplicar filas) → 1 query.
+      //   2) `waitListUsers` (la SEGUNDA to-many) se puebla aparte por select-in.
+      // Juntar users×waitListUsers en el mismo JOIN sí explotaría en cartesiano;
+      // separarlas mantiene el coste constante tanto con pocos como con muchos
+      // apuntados. Seguimos usando find(), así que el filtro companyContext se
+      // aplica solo (imposible olvidarlo) y el contrato GraphQL no cambia.
       const schedules = await scheduleRepo.find(
         {
           startDate: { $gte: startOfDay, $lte: endOfDay },
         },
-        { populate: ['users', 'admin', 'waitListUsers'] }
+        { populate: ['users', 'admin'], strategy: LoadStrategy.JOINED }
       );
+
+      await this.em.populate(schedules, ['waitListUsers'], {
+        strategy: LoadStrategy.SELECT_IN,
+      });
 
       const sortSchedules = [...schedules].sort((a, b) => {
         return moment(a.startDate).unix() - moment(b.startDate).unix();


### PR DESCRIPTION
- **perf(schedule): resolve getSchedulesResumeRange in a single DB round-trip**
- **refactor(schedule): use MikroORM QueryBuilder instead of raw SQL**
- **perf(schedule): cut getSchedulesRange to 2 round-trips via mixed load strategy**
